### PR TITLE
Changes related to julia 1.0

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ provides(AptGet, "libmp3lame-dev", lame)
 provides(Pacman, "mpg123", mpg123)
 provides(Pacman, "lame", lame)
 
-@static if is_apple()
+@static if Sys.isapple()
     if Pkg.installed("Homebrew") === nothing
         error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
     end
@@ -20,7 +20,7 @@ provides(Pacman, "lame", lame)
     provides(Homebrew.HB, "lame", lame)
 end
 
-@static if is_windows()
+@static if Sys.iswindows()
     if Sys.WORD_SIZE == 32
         provides(Binaries, URI("http://www.rarewares.org/files/mp3/libmp3lame-3.99.5x86.zip"), lame,
                  SHA="7bf2a33de715d968e5ef5049b7b18e34b9ae98224842293adcdc6f6f23ad9b76",

--- a/src/MP3.jl
+++ b/src/MP3.jl
@@ -3,12 +3,13 @@ __precompile__()
 module MP3
 
 deps = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
-isfile(deps)? include(deps) : error("MP3 is not properly installed. Please run: Pkg.build(\"MP3\")")
+isfile(deps) ? include(deps) : error("MP3 is not properly installed. Please run: Pkg.build(\"MP3\")")
 
 # package code goes here
 using SampledSignals
 using FileIO
 using FixedPointNumbers
+using LinearAlgebra #tranpose!()
 
 # methods to override
 import SampledSignals: nchannels, nframes, samplerate, unsafe_read!, unsafe_write
@@ -18,7 +19,7 @@ import FileIO: load, save
 export load, save
 export Hz, kHz, s
 
-type MP3INFO
+struct MP3INFO
     nframes::Int64
     nchannels::Int32
     samplerate::Int32
@@ -26,7 +27,7 @@ type MP3INFO
 end
 
 """create an MP3INFO object from given audio buffer"""
-function MP3INFO{T}(buf::SampleBuf{T})
+function MP3INFO(buf::SampleBuf{T}) where {T}
     MP3INFO(nframes(buf), nchannels(buf), samplerate(buf), T)
 end
 

--- a/src/lame.jl
+++ b/src/lame.jl
@@ -1,7 +1,7 @@
 # lame wrappers of required functions to write mp3 files
 
 """represents the C pointer lame_global_flags*. used by all LAME functions"""
-const LAME = Ptr{Void}
+const LAME = Ptr{Cvoid}
 
 """meaning of LAME return codes, usually only relevant to lame_encode_buffer families"""
 LAME_ERRORS = Dict{Int, String}(
@@ -192,17 +192,17 @@ end
 
 """initialize ID3 tag"""
 function id3tag_init(lame::LAME)
-    ccall((:id3tag_init, libmp3lame), Void, (LAME,), lame)
+    ccall((:id3tag_init, libmp3lame), Cvoid, (LAME,), lame)
 end
 
 """tell LAME to add ID3v2"""
 function id3tag_add_v2(lame::LAME)
-    ccall((:id3tag_add_v2, libmp3lame), Void, (LAME,), lame)
+    ccall((:id3tag_add_v2, libmp3lame), Cvoid, (LAME,), lame)
 end
 
 """force using ID3v2 and not ID3v1"""
 function id3tag_v2_only(lame::LAME)
-    ccall((:id3tag_v2_only, libmp3lame), Void, (LAME,), lame)
+    ccall((:id3tag_v2_only, libmp3lame), Cvoid, (LAME,), lame)
 end
 
 """set ID3v2 unicode tag for title"""
@@ -239,7 +239,7 @@ end
 
 """prevent LAME from writing ID3 tags"""
 function lame_set_write_id3tag_automatic(lame::LAME, v::Integer)
-    ccall((:lame_set_write_id3tag_automatic, libmp3lame), Void,
+    ccall((:lame_set_write_id3tag_automatic, libmp3lame), Cvoid,
           (LAME, Cint), lame, v)
 end
 

--- a/src/mpg123.jl
+++ b/src/mpg123.jl
@@ -29,7 +29,7 @@ const MPG123_ENC_ANY = ( MPG123_ENC_SIGNED_16  | MPG123_ENC_UNSIGNED_16
 	                   | MPG123_ENC_FLOAT_32   | MPG123_ENC_FLOAT_64    )
 
 """represents the C pointer mpg123_handle*. used by all mpg123 functions"""
-const MPG123 = Ptr{Void}
+const MPG123 = Ptr{Cvoid}
 
 const MPG123_DONE               = -12
 const MPG123_NEW_FORMAT         = -11
@@ -138,7 +138,7 @@ read audio samples from the mpg123 handle
 * `out::Array{T}`: Array with appropriate data type, to store the samples
 * `size::Integer`: the amount to read, in bytes. nchannels * encsize * nsamples
 """
-function mpg123_read!{T}(mpg123::MPG123, out::Array{T}, size::Integer)
+function mpg123_read!(mpg123::MPG123, out::Array{T}, size::Integer) where {T}
     done = Ref{Csize_t}(0)
     err = ccall((:mpg123_read, libmpg123), Cint,
                 (MPG123, Ptr{T}, Csize_t, Ref{Csize_t}),

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -16,14 +16,14 @@ mutable struct MP3FileSource{T} <: SampleSource
 end
 
 function MP3FileSource(path::AbstractString, mpg123::MPG123, info::MP3INFO, bufsize::Integer)
-    readbuf = Array{info.datatype}(info.nchannels, bufsize)
+    readbuf = Array{info.datatype}(undef,info.nchannels, bufsize)
     MP3FileSource(path, mpg123, info, Int64(0), readbuf)
 end
 
 @inline nchannels(source::MP3FileSource) = Int(source.info.nchannels)
 @inline samplerate(source::MP3FileSource) = source.info.samplerate
 @inline nframes(source::MP3FileSource) = source.info.nframes
-@inline Base.eltype{T}(source::MP3FileSource{T}) = T
+@inline Base.eltype(source::MP3FileSource{T}) where {T} = T 
 
 """convert mpg123 encoding to julia datatype"""
 function encoding_to_type(encoding)
@@ -96,7 +96,7 @@ function unsafe_read!(source::MP3FileSource, buf::Array, frameoffset, framecount
         nr = mpg123_read!(mpg123, readbuf, n * encsize * nchans)
         nr = div(nr, encsize * nchans)
 
-        transpose!(view(buf, (1:nr)+nread+frameoffset, :), view(readbuf, :, 1:nr))
+        transpose!(view(buf, (1:nr) .+ nread .+ frameoffset, :), view(readbuf, :, 1:nr))
 
         source.pos += nr
         nread += nr


### PR DESCRIPTION
MP3.jl was broken for me with julia 1.0.
Changes that I made were related to:
* Array requires `undef`
* `transpose!()` requieres `LinearAlgebra` package
* type definition and parametric functions keyword/syntax changes